### PR TITLE
feat(tanstack-trpc): add router utility for TanStack integration

### DIFF
--- a/apps/tanstack-trpc-app/src/integrations/tanstack-query/layout.tsx
+++ b/apps/tanstack-trpc-app/src/integrations/tanstack-query/layout.tsx
@@ -1,5 +1,5 @@
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-export default function LayoutAddition() {
+export function TanstackQueryLayoutAddition() {
   return <ReactQueryDevtools buttonPosition="bottom-right" />;
 }

--- a/apps/tanstack-trpc-app/src/router.tsx
+++ b/apps/tanstack-trpc-app/src/router.tsx
@@ -1,40 +1,22 @@
-import { createRouter as createTanstackRouter } from '@tanstack/react-router';
-import { routerWithQueryClient } from '@tanstack/react-router-with-query';
 import { createContext } from '@workspace/tanstack-trpc/context';
+import { createTanstackWithQueryAndTRPCRouter } from '@workspace/tanstack-trpc/router';
 import { TRPCRouter } from '@/integrations/trpc/router';
 import { TRPCProvider } from '@/integrations/trpc/react';
 
 // Import the generated route tree
 import { routeTree } from './routeTree.gen';
 
-// Create a new router instance
+// Create a new router instanc
 export const createRouter = () => {
   const context = createContext<TRPCRouter>();
 
-  const router = routerWithQueryClient(
-    createTanstackRouter({
-      routeTree,
-      context,
-      scrollRestoration: true,
-      defaultPreloadStaleTime: 0,
-
-      Wrap: (props: { children: React.ReactNode }) => {
-        return (
-          <TRPCProvider
-            context={{
-              queryClient: context.queryClient,
-              trpcClient: context.trpcClient,
-            }}
-          >
-            {props.children}
-          </TRPCProvider>
-        );
-      },
-    }),
-    context.queryClient
-  );
-
-  return router;
+  return createTanstackWithQueryAndTRPCRouter<TRPCRouter, typeof routeTree>({
+    routeTree,
+    context,
+    scrollRestoration: true,
+    defaultPreloadStaleTime: 0,
+    Provider: TRPCProvider,
+  });
 };
 
 // Register the router instance for type safety

--- a/apps/tanstack-trpc-app/src/routes/__root.tsx
+++ b/apps/tanstack-trpc-app/src/routes/__root.tsx
@@ -6,7 +6,7 @@ import {
 } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 
-import TanstackQueryLayout from '../integrations/tanstack-query/layout';
+import { TanstackQueryLayoutAddition } from '@/integrations/tanstack-query/layout';
 
 import appCss from '@workspace/ui/globals.css?url';
 
@@ -37,7 +37,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
     // Use stale-while-revalidate pattern with caching
     const user = await getUserInfo();
 
-    return { user };
+    return { user }
   },
   head: () => ({
     meta: [
@@ -94,8 +94,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
         </AppLayout>
       </ThemeProvider>
       <TanStackRouterDevtools />
-
-      <TanstackQueryLayout />
+      <TanstackQueryLayoutAddition />
     </RootDocument>
   ),
 

--- a/packages/tanstack-trpc/README.md
+++ b/packages/tanstack-trpc/README.md
@@ -1,9 +1,118 @@
-# tanstack trpc 
+# tanstack-trpc
 
-This library was generated with [Nx](https://nx.dev).
+The `tanstack-trpc` package provides utilities and integrations for working with tRPC in the context of TanStack projects. This package is scaffolded and managed using [Nx](https://nx.dev), ensuring a modular and maintainable monorepo structure.
+
+## Features
+
+- Seamless integration of tRPC with TanStack libraries.
+- Designed for use within Nx-managed monorepos.
+- Includes unit tests powered by [Vitest](https://vitest.dev/).
+
+## Usage
+
+To run the unit tests for this package, execute:
+```
+nx test tanstack-trpc
+```
+
+For more information, refer to the official documentation of [Nx](https://nx.dev) and [Vitest](https://vitest.dev/).
 
 
+## Example
 
-## Running unit tests
+```typescript
 
-Run `nx test tanstack-trpc` to execute the unit tests via [Vitest](https://vitest.dev/).
+// integrations/trpc/router.ts
+import {
+  getTRPCInstance,
+} from '@workspace/trpc/init';
+import { z } from 'zod';
+
+const t = getTRPCInstance();
+const createTRPCRouter = t.router;
+
+export const trpcRouter = createTRPCRouter({
+  greeting: t.procedure
+    .input(z.object({ name: z.string() }))
+    .query(({ input }) => {
+      return `Hello, ${input.name}!`;
+    }),
+});
+
+export type TRPCRouter = typeof trpcRouter;
+
+// integrations/trpc/react.ts
+
+import type { TRPCRouter } from '@/integrations/trpc/router';
+import { createProvider } from '@workspace/tanstack-trpc/provider';
+
+export const { TRPCProvider, useTRPC } = createProvider<TRPCRouter>();
+
+```
+
+### React client application example
+
+```typescript
+// app.tsx
+import React from 'react';
+import { createContext } from '@workspace/tanstack-trpc';
+import { createProvider } from '@workspace/tanstack-trpc';
+import { TRPCRouter } from '@/integrations/trpc/router';
+
+// 1. Create the tRPC context
+const trpcContext = createContext<TRPCRouter>();
+
+// 2. Create the provider
+const { TRPCProvider, useTRPC } = createProvider<TRPCRouter>();
+
+// 3. Create a component that uses the tRPC hook
+function GreetingComponent() {
+  const trpc = useTRPC();
+  const { data, isLoading } = trpc.greeting.useQuery({ name: 'World' });
+
+  if (isLoading) return <div>Loading...</div>;
+  return <div>{data}</div>;
+}
+
+// 4. Use the provider in your app
+export function App() {
+  return (
+    <TRPCProvider context={trpcContext}>
+      <GreetingComponent />
+    </TRPCProvider>
+  );
+}
+```
+
+### Tanstack start router example
+
+```typescript
+// router.tsx
+import { createContext } from '@workspace/tanstack-trpc/context';
+import { createTanstackWithQueryAndTRPCRouter } from '@workspace/tanstack-trpc/router';
+import { TRPCRouter } from '@/integrations/trpc/router';
+import { TRPCProvider } from '@/integrations/trpc/react';
+
+// Import the generated route tree
+import { routeTree } from './routeTree.gen';
+
+// Create a new router instanc
+export const createRouter = () => {
+  const context = createContext<TRPCRouter>();
+
+  return createTanstackWithQueryAndTRPCRouter<TRPCRouter, typeof routeTree>({
+    routeTree,
+    context,
+    scrollRestoration: true,
+    defaultPreloadStaleTime: 0,
+    Provider: TRPCProvider,
+  });
+};
+
+// Register the router instance for type safety
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: ReturnType<typeof createRouter>;
+  }
+}
+```

--- a/packages/tanstack-trpc/package.json
+++ b/packages/tanstack-trpc/package.json
@@ -6,7 +6,8 @@
   "exports": {
     "./query-client": "./src/query-client.ts",
     "./context": "./src/context.tsx",
-    "./provider": "./src/provider.tsx"
+    "./provider": "./src/provider.tsx",
+    "./router": "./src/router.tsx"
   },
   "devDependencies": {
     "@types/node": "^22.9.0",
@@ -20,7 +21,9 @@
   },
   "dependencies": {
     "superjson": "^1.0.0",
+    "@tanstack/react-router": "^1.120.3",
     "@tanstack/react-query": "^5.76.0",
+    "@tanstack/react-router-with-query": "^1.120.3",
     "@trpc/tanstack-react-query": "^11.1.1",
     "@trpc/server": "^11.1.1",
     "@workspace/trpc": "workspace:*",

--- a/packages/tanstack-trpc/src/context.tsx
+++ b/packages/tanstack-trpc/src/context.tsx
@@ -3,6 +3,23 @@ import { AnyTRPCRouter } from '@trpc/server';
 import { createTRPCClient } from '@workspace/trpc/client';
 import { createQueryClient } from '@workspace/tanstack-trpc/query-client';
 
+/**
+ * Creates a context object with configured tRPC and TanStack Query clients
+ * 
+ * This function initializes and combines the necessary clients to work with tRPC and
+ * TanStack Query. It creates a queryClient, trpcClient, and
+ * serverHelpers to provide a complete context for data fetching operations.
+ * 
+ * Mean to be used with conjuction with `createProvider` TRPCProvider 
+ * and `useTRPC` hooks. 
+ * 
+ * @template TRouter - The type of your tRPC router
+ * @returns {Object} The context object containing:
+ *   - queryClient: TanStack Query client instance
+ *   - trpc: tRPC proxy with TanStack Query integration
+ *   - trpcClient: Raw tRPC client instance
+ *
+ */
 export function createContext<TRouter extends AnyTRPCRouter>() {
   const queryClient = createQueryClient();
   const trpcClient = createTRPCClient<TRouter>();

--- a/packages/tanstack-trpc/src/provider.tsx
+++ b/packages/tanstack-trpc/src/provider.tsx
@@ -3,6 +3,14 @@ import { createTRPCContext } from '@trpc/tanstack-react-query';
 import { createContext } from '@workspace/tanstack-trpc/context';
 import React from 'react';
 
+/**
+ * Creates react context provider and hook for the given router.
+ *
+ * This is a wrapper around `createTRPCContext` that also creates 
+ * a `createContext` function that can be used to create a context
+ * for the router.
+ *
+ */
 export const createProvider = <TRouter extends AnyTRPCRouter>() => {
   const { TRPCProvider, useTRPC } = createTRPCContext<TRouter>();
 

--- a/packages/tanstack-trpc/src/router.tsx
+++ b/packages/tanstack-trpc/src/router.tsx
@@ -1,0 +1,68 @@
+import {
+  AnyRoute,
+  createRouter as createTanstackRouter,
+  RouterConstructorOptions,
+  RouterHistory,
+  TrailingSlashOption,
+} from '@tanstack/react-router';
+import {
+  routerWithQueryClient,
+  ValidateRouter,
+} from '@tanstack/react-router-with-query';
+import { createContext } from '@workspace/tanstack-trpc/context';
+import { AnyTRPCRouter } from '@trpc/server';
+import { createProvider } from '@workspace/tanstack-trpc/provider';
+
+// Create a new router instance
+export const createTanstackWithQueryAndTRPCRouter = <
+  TTRPCRouter extends AnyTRPCRouter,
+  TRouteTree extends AnyRoute,
+  TTrailingSlashOption extends TrailingSlashOption = 'never',
+  TDefaultStructuralSharingOption extends boolean = false,
+  TRouterHistory extends RouterHistory = RouterHistory,
+  TDehydrated extends Record<string, any> = Record<string, any>
+>({
+  Provider,
+  context,
+  ...options
+}: RouterConstructorOptions<
+  TRouteTree,
+  TTrailingSlashOption,
+  TDefaultStructuralSharingOption,
+  TRouterHistory,
+  TDehydrated
+> & {
+  Provider: ReturnType<typeof createProvider<TTRPCRouter>>['TRPCProvider'];
+  context: TRouteTree['types']['routerContext'] &
+    ReturnType<typeof createContext<TTRPCRouter>>;
+}) => {
+  const tanstackRouter = createTanstackRouter<
+    TRouteTree,
+    TTrailingSlashOption,
+    TDefaultStructuralSharingOption,
+    TRouterHistory,
+    TDehydrated
+  >({
+    ...options,
+    context,
+    Wrap: (props: { children: React.ReactNode }) => {
+      return (
+        <Provider
+          context={{
+            queryClient: context.queryClient,
+            trpcClient: context.trpcClient,
+          }}
+        >
+          {props.children}
+        </Provider>
+      );
+    },
+  });
+
+  const router = routerWithQueryClient(
+    tanstackRouter as ValidateRouter<typeof tanstackRouter>,
+    context.queryClient
+  );
+
+  return router;
+};

--- a/packages/user-trpc/README.md
+++ b/packages/user-trpc/README.md
@@ -1,11 +1,30 @@
-# user trpc
+# @workspace/user-trpc
 
-This library was generated with [Nx](https://nx.dev).
+This library was generated with Nx.
+
+## Overview
+
+`@workspace/user-trpc` provides tRPC endpoints and routers for user management functionality. It integrates with Supabase for user data operations via the [`@workspace/user-supabase`](../user-supabase) package.
 
 ## Building
 
-Run `nx build user-trpc` to build the library.
+This package is not buildable
 
-## Running unit tests
+## Running Unit Tests
 
-Run `nx test utils` to execute the unit tests via [Vitest](https://vitest.dev/).
+To execute the unit tests with Vitest, run:
+
+```bash
+nx test user-trpc
+```
+
+## Usage
+
+Import the user tRPC routers in your tRPC API to add user management functionality:
+
+```ts
+import { userRouter } from '@workspace/user-trpc';
+// Add userRouter to your tRPC app/router
+```
+
+This gives your application access to type-safe user management operations through tRPC.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,7 +167,7 @@ importers:
         version: 8.19.4
       '@tanstack/react-form':
         specifier: ^1.11.1
-        version: 1.11.1(@tanstack/react-start@1.120.3(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vinxi@0.5.3(@types/node@22.15.17)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+        version: 1.11.1(@tanstack/react-start@1.120.3(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vinxi@0.5.3(@types/node@22.15.17)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
       '@tanstack/react-query':
         specifier: ^5.76.0
         version: 5.76.0(react@19.0.0)
@@ -185,7 +185,7 @@ importers:
         version: 1.120.3(@tanstack/react-query@5.76.0(react@19.0.0))(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/router-core@1.120.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/react-start':
         specifier: ^1.120.3
-        version: 1.120.3(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)
+        version: 1.120.3(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)
       '@tanstack/react-store':
         specifier: ^0.7.0
         version: 0.7.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -257,7 +257,7 @@ importers:
         version: 4.0.12
       vinxi:
         specifier: ^0.5.3
-        version: 0.5.3(@types/node@22.15.17)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+        version: 0.5.3(@types/node@22.15.17)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.3)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
@@ -303,7 +303,7 @@ importers:
         version: 4.0.12(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
       '@tanstack/react-form':
         specifier: ^1.11.1
-        version: 1.11.1(@tanstack/react-start@1.120.3(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vinxi@0.5.3(@types/node@22.15.17)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+        version: 1.11.1(@tanstack/react-start@1.120.3(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vinxi@0.5.3(@types/node@22.15.17)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
       '@tanstack/react-query':
         specifier: ^5.76.0
         version: 5.76.0(react@19.0.0)
@@ -321,10 +321,10 @@ importers:
         version: 1.120.3(@tanstack/react-query@5.76.0(react@19.0.0))(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/router-core@1.120.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/react-start':
         specifier: ^1.120.3
-        version: 1.120.3(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)
+        version: 1.120.3(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)
       '@tanstack/start':
         specifier: ^1.120.3
-        version: 1.120.3(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)
+        version: 1.120.3(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)
       '@tanstack/virtual-file-routes':
         specifier: ^1.115.0
         version: 1.115.0
@@ -372,7 +372,7 @@ importers:
         version: 2.8.1
       vinxi:
         specifier: ^0.5.3
-        version: 0.5.3(@types/node@22.15.17)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+        version: 0.5.3(@types/node@22.15.17)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       vite:
         specifier: ^6.0.0
         version: 6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
@@ -1294,6 +1294,12 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.76.0
         version: 5.76.0(react@19.0.0)
+      '@tanstack/react-router':
+        specifier: ^1.120.3
+        version: 1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@tanstack/react-router-with-query':
+        specifier: ^1.120.3
+        version: 1.120.3(@tanstack/react-query@5.76.0(react@19.0.0))(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/router-core@1.120.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@trpc/server':
         specifier: ^11.1.1
         version: 11.1.1(typescript@5.8.3)
@@ -21659,69 +21665,6 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/start-config@1.120.3(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)':
-    dependencies:
-      '@tanstack/react-router': 1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@tanstack/react-start-plugin': 1.115.0(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      '@tanstack/router-generator': 1.120.3(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
-      '@tanstack/router-plugin': 1.120.3(@tanstack/react-router@1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))
-      '@tanstack/server-functions-plugin': 1.119.2(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      '@tanstack/start-server-functions-handler': 1.120.3
-      '@vitejs/plugin-react': 4.4.1(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
-      import-meta-resolve: 4.1.0
-      nitropack: 2.11.11(encoding@0.1.13)
-      ofetch: 1.4.1
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      vinxi: 0.5.3(@types/node@22.15.17)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      vite: 6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      zod: 3.24.4
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@rsbuild/core'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/kv'
-      - aws4fetch
-      - babel-plugin-macros
-      - better-sqlite3
-      - db0
-      - debug
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - ioredis
-      - jiti
-      - less
-      - lightningcss
-      - mysql2
-      - rolldown
-      - sass
-      - sass-embedded
-      - sqlite3
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - uploadthing
-      - vite-plugin-solid
-      - webpack
-      - xml2js
-      - yaml
-
   '@tanstack/start-config@1.120.3(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)':
     dependencies:
       '@tanstack/react-router': 1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -21926,66 +21869,6 @@ snapshots:
       - supports-color
       - terser
       - tsx
-      - yaml
-
-  '@tanstack/start@1.120.3(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)':
-    dependencies:
-      '@tanstack/react-start-client': 1.120.3(@types/node@22.15.17)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      '@tanstack/react-start-router-manifest': 1.120.3(@types/node@22.15.17)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      '@tanstack/react-start-server': 1.120.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@tanstack/start-api-routes': 1.120.3(@types/node@22.15.17)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      '@tanstack/start-config': 1.120.3(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.1)(encoding@0.1.13)(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)
-      '@tanstack/start-server-functions-client': 1.120.3(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      '@tanstack/start-server-functions-handler': 1.120.3
-      '@tanstack/start-server-functions-server': 1.119.2(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-      '@tanstack/start-server-functions-ssr': 1.120.3(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@rsbuild/core'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/kv'
-      - aws4fetch
-      - babel-plugin-macros
-      - better-sqlite3
-      - db0
-      - debug
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - ioredis
-      - jiti
-      - less
-      - lightningcss
-      - mysql2
-      - react
-      - react-dom
-      - rolldown
-      - sass
-      - sass-embedded
-      - sqlite3
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - uploadthing
-      - vite
-      - vite-plugin-solid
-      - webpack
-      - xml2js
       - yaml
 
   '@tanstack/start@1.120.3(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(db0@0.3.2)(encoding@0.1.13)(ioredis@5.6.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(vite@6.2.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.25.4))(yaml@2.7.1)':


### PR DESCRIPTION
# Refactor Router Creation with createTanstackWithQueryAndTRPCRouter

This PR introduces a new utility function `createTanstackWithQueryAndTRPCRouter` that simplifies the integration between TanStack Router, TanStack Query, and tRPC. The function encapsulates the boilerplate code needed to set up these libraries together.

Key changes:
- Renamed `LayoutAddition` to `TanstackQueryLayoutAddition` for better naming consistency
- Refactored router creation in the app to use the new utility function
- Added comprehensive documentation to the tanstack-trpc package README
- Added JSDoc comments to explain the purpose and usage of context and provider functions
- Updated package.json to export the new router utility
- Enhanced the user-trpc README with clearer usage instructions

This change makes it easier to set up and maintain applications that use these technologies together, reducing boilerplate and improving developer experience.